### PR TITLE
feat: init swagger UI; add error-message helper; update error handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,12 @@
     "test": "jest"
   },
   "dependencies": {
+    "@hono/swagger-ui": "^0.2.2",
+    "@hono/zod-openapi": "^0.11.1",
     "@hono/zod-validator": "^0.2.1",
+    "@types/jsonwebtoken": "^9.0.6",
     "hono": "^4.3.0",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.3.3",
     "zod": "^3.23.8"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,8 @@
-import { Context, Hono } from 'hono'
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { swaggerUI } from '@hono/swagger-ui'
 import { logger } from 'hono/logger'
 import { cors } from 'hono/cors'
+
 import mongoose from 'mongoose'
 
 import { checkEnvironmentVariables } from './config/environment'
@@ -16,18 +18,33 @@ const mongodbUri =
 
 mongoose.connect(mongodbUri)
 
-const app = new Hono()
+const app = new OpenAPIHono()
 
 app.use('*', logger())
 app.use(cors())
 
 setupRoutes(app) // 添加新的路由
 
+app.doc('/doc', {
+  openapi: '3.0.0',
+  info: {
+    version: '1.0.0',
+    title: 'Movie Rating',
+  },
+})
+
+app.openAPIRegistry.registerComponent('securitySchemes', 'JWT_Token', {
+  type: 'http',
+  scheme: 'bearer',
+  bearerFormat: 'JWT',
+})
+
+app.get('/ui', swaggerUI({ url: '/doc' }))
+
 app.get('/', (c) => {
   return c.text('Hello Hono!')
 })
-;(app.onError as any)((err: Error, c: Context, next: () => void) =>
-  handleApiError(err, c, next)
-)
+
+app.onError((err: Error, c: any) => handleApiError(err, c))
 
 export default app

--- a/src/controllers/dislike.ts
+++ b/src/controllers/dislike.ts
@@ -1,18 +1,30 @@
+import jwt from 'jsonwebtoken'
+
 import { Comment, Dislike } from '../models'
-import { Context } from 'hono'
 
 import { idCheck } from '../middlewares/validation'
+import { errorMessage } from '../helpers/error-message'
 
 export const dislikeController = {
-  dislikeComment: async (c: Context) => {
-    const { id: userId } = c.get('jwtPayload')
+  dislikeComment: async (c: any) => {
+    const token = c.req.header('Authorization')?.split(' ')[1]
+
+    if (token == null) {
+      const message = 'no authorization included in request.'
+      const name = 'ServerError'
+
+      return errorMessage(c, 401, message, name)
+    }
+
+    const payload: any = jwt.verify(token, process.env.JWT_SECRET!)
+    const { id: userId } = payload
     const { commentId } = c.req.param()
 
     if (idCheck(commentId)) {
-      c.status(400)
-      return c.json({
-        errors: [{ message: 'Invalid commentId.' }],
-      })
+      const message = 'Invalid commentId.'
+      const name = 'ZodError'
+
+      return errorMessage(c, 400, message, name)
     }
 
     const [currentComment, likedComment] = await Promise.all([
@@ -21,48 +33,57 @@ export const dislikeController = {
     ])
 
     if (currentComment == null) {
-      c.status(400)
-      return c.json({
-        errors: [{ message: "Comment doesn't existed." }],
-      })
+      const message = "Comment doesn't existed."
+      const name = 'DataBaseError'
+
+      return errorMessage(c, 404, message, name)
     }
 
     if (likedComment != null) {
-      c.status(400)
-      return c.json({
-        errors: [{ message: 'You already disliked this comment.' }],
-      })
+      const message = 'You already disliked this comment.'
+      const name = 'DataBaseError'
+
+      return errorMessage(c, 400, message, name)
     }
 
-    return c.json(await Dislike.create({ userId, commentId }))
+    return c.json({
+      success: true,
+      data: await Dislike.create({ userId, commentId }),
+    })
   },
-  undoDislikeComment: async (c: Context) => {
-    const { id: userId } = c.get('jwtPayload')
+  undoDislikeComment: async (c: any) => {
+    const token = c.req.header('Authorization')?.split(' ')[1]
+
+    if (token == null) {
+      const message = 'no authorization included in request.'
+      const name = 'ServerError'
+
+      return errorMessage(c, 401, message, name)
+    }
+
+    const payload: any = jwt.verify(token, process.env.JWT_SECRET!)
+    const { id: userId } = payload
     const { commentId } = c.req.param()
 
     if (idCheck(commentId)) {
-      c.status(400)
-      return c.json({
-        errors: [{ message: 'Invalid commentId.' }],
-      })
+      const message = 'Invalid commentId.'
+      const name = 'ZodError'
+
+      return errorMessage(c, 400, message, name)
     }
 
     const likedComment = await Dislike.findOne({ userId, commentId })
 
     if (likedComment == null) {
-      c.status(400)
-      return c.json({
-        errors: [{ message: "You haven't disliked this comment yet." }],
-      })
+      const message = "You haven't disliked this comment yet."
+      const name = 'DataBaseError'
+
+      return errorMessage(c, 400, message, name)
     }
 
-    if (String(likedComment.userId) !== userId) {
-      c.status(400)
-      return c.json({
-        errors: [{ message: 'Insufficient permissions.' }],
-      })
-    }
-
-    return c.json(await Dislike.findOneAndDelete({ userId, commentId }))
+    return c.json({
+      success: true,
+      data: await Dislike.findOneAndDelete({ userId, commentId }),
+    })
   },
 }

--- a/src/helpers/error-message.ts
+++ b/src/helpers/error-message.ts
@@ -1,0 +1,21 @@
+import { StatusCode } from 'hono/utils/http-status'
+
+export function errorMessage(
+  c: any,
+  status: StatusCode,
+  message: string,
+  name: string = 'ServerError'
+) {
+  c.status(status)
+  return c.json({
+    success: false,
+    error: {
+      issues: [
+        {
+          message,
+        },
+      ],
+      name,
+    },
+  })
+}

--- a/src/middlewares/error-handler.ts
+++ b/src/middlewares/error-handler.ts
@@ -1,14 +1,11 @@
 import { Context } from 'hono'
+import { StatusCode } from 'hono/utils/http-status'
+import { errorMessage } from '../helpers/error-message'
 
-export function handleApiError(err: Error, c: Context, next: () => void) {
-  // 如果有錯誤發生，則處理錯誤；如果沒有錯誤，將控制權交給下一個中間件或路由
-  return err != null
-    ? err.message != null
-      ? c.json({
-          errors: [{ message: err.message }],
-        })
-      : c.json({
-          errors: [{ message: err }],
-        })
-    : next()
+interface ApiError extends Error {
+  status?: StatusCode
+}
+
+export function handleApiError(err: ApiError, c: Context) {
+  return errorMessage(c, err.status ?? 500, err.message ?? err)
 }

--- a/src/routes/category.ts
+++ b/src/routes/category.ts
@@ -1,7 +1,7 @@
-import { Hono } from 'hono'
+import { OpenAPIHono } from '@hono/zod-openapi'
 import { categoryController } from '../controllers/category'
 
-export function categoryRoute(app: Hono) {
+export function categoryRoute(app: OpenAPIHono) {
   app.get('/api/category', categoryController.getCategories)
   app.get('/api/category/:cid', categoryController.getCategory)
   app.post('/api/category', categoryController.postCategory)

--- a/src/routes/comment.ts
+++ b/src/routes/comment.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono'
+import { OpenAPIHono } from '@hono/zod-openapi'
 import { jwt } from 'hono/jwt'
 import { z } from 'zod'
 import { zValidator } from '@hono/zod-validator'
@@ -13,7 +13,7 @@ const commentSchema = z.object({
   comment: z.string(),
 })
 
-export function commentRoute(app: Hono) {
+export function commentRoute(app: OpenAPIHono) {
   app.get('/api/comments', commentController.getComments)
   app.post(
     '/api/comments/:movieId',

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,9 +1,9 @@
-import { Hono } from 'hono'
+import { OpenAPIHono } from '@hono/zod-openapi'
 import { categoryRoute } from './category'
 import { commentRoute } from './comment'
 import { userRoute } from './user'
 
-export function setupRoutes(app: Hono) {
+export function setupRoutes(app: OpenAPIHono) {
   categoryRoute(app)
   commentRoute(app)
   userRoute(app)

--- a/src/routes/user.ts
+++ b/src/routes/user.ts
@@ -1,9 +1,6 @@
-import { Hono } from 'hono'
+import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi'
 import { jwt } from 'hono/jwt'
-import { z } from 'zod'
-import { zValidator } from '@hono/zod-validator'
 
-import { validationErrorHandler } from '../middlewares/validation'
 import { favoriteController } from '../controllers/favorite'
 import { dislikeController } from '../controllers/dislike'
 import { likeController } from '../controllers/like'
@@ -13,76 +10,408 @@ const secret = process.env.JWT_SECRET as string
 
 const signupSchema = z
   .object({
-    name: z.string(),
-    email: z.string().email(),
-    password: z.string(),
-    confirmedPassword: z.string(),
+    name: z.string().min(1).openapi({
+      example: 'test',
+    }),
+    email: z.string().email().openapi({
+      example: 'test@example.com',
+    }),
+    password: z.string().min(3).openapi({
+      example: '123456',
+    }),
+    confirmedPassword: z.string().min(3).openapi({
+      example: '123456',
+    }),
   })
-  .refine((data) => data.password === data.confirmedPassword, {
-    message: "Passwords don't match",
-    path: ['confirmedPassword'],
-  })
+  .refine(
+    (data) => data.password === data.confirmedPassword,
+    () => ({
+      code: undefined,
+      message: "Passwords don't match",
+      path: ['confirmedPassword'],
+    })
+  )
 
 const signinSchema = z.object({
-  email: z.string().email(),
-  password: z.string(),
+  email: z.string().email().openapi({
+    example: 'test@example.com',
+  }),
+  password: z.string().openapi({
+    example: '123456',
+  }),
 })
 
-export function userRoute(app: Hono) {
-  app.post(
-    '/api/signup',
-    zValidator('json', signupSchema, (result, c) =>
-      validationErrorHandler(result, c, 400)
-    ),
-    userController.signUp
-  )
-  app.post(
-    '/api/signin',
-    zValidator('json', signinSchema, (result, c) =>
-      validationErrorHandler(result, c, 400)
-    ),
-    userController.signIn
-  )
-  app.post(
-    '/api/favorites/:movieId',
-    jwt({
-      secret,
-    }),
-    favoriteController.addFavorite
-  )
-  app.delete(
-    '/api/favorites/:movieId',
-    jwt({
-      secret,
-    }),
-    favoriteController.removeFavorite
-  )
-  app.post(
-    '/api/like/:commentId',
-    jwt({
-      secret,
-    }),
-    likeController.likeComment
-  )
-  app.delete(
-    '/api/like/:commentId',
-    jwt({
-      secret,
-    }),
-    likeController.undoLikeComment
-  )
-  app.post(
-    '/api/dislike/:commentId',
-    jwt({
-      secret,
-    }),
-    dislikeController.dislikeComment
-  )
-  app.delete(
-    '/api/dislike/:commentId',
-    jwt({
-      secret,
-    }),
-    dislikeController.undoDislikeComment
-  )
+const POST_signUp = createRoute({
+  tags: ['User'],
+  summary: '送出使用者註冊資料',
+  description: 'name, email, password, confirmedPassword 為必填',
+  method: 'post',
+  path: '/api/signup',
+  request: {
+    body: { content: { 'application/json': { schema: signupSchema } } },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.boolean().openapi({
+              example: true,
+            }),
+            data: z.object({
+              name: z.string().openapi({
+                example: 'Jarred Sumner',
+              }),
+              email: z.string().openapi({
+                example: 'jarred@example.com',
+              }),
+              _id: z.string().openapi({
+                example: '66443b101236ec4082a30b40',
+              }),
+              createAt: z.string().openapi({
+                example: '2024-05-15T03:30:00.000Z',
+              }),
+              __v: z.number().openapi({
+                example: 0,
+              }),
+            }),
+          }),
+        },
+      },
+      description: '註冊成功的使用者資料',
+    },
+  },
+})
+
+const POST_signIn = createRoute({
+  tags: ['User'],
+  summary: '送出使用者登入資料',
+  description: 'email 及 password 為必填',
+  method: 'post',
+  path: '/api/signin',
+  request: {
+    body: { content: { 'application/json': { schema: signinSchema } } },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.boolean().openapi({
+              example: true,
+            }),
+            data: z.object({
+              _id: z.string().openapi({
+                example: '66443b101236ec4082a30b40',
+              }),
+              name: z.string().openapi({
+                example: 'Jarred Sumner',
+              }),
+              email: z.string().openapi({
+                example: 'jarred@example.com',
+              }),
+              token: z.string().openapi({
+                example:
+                  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY2NDQzYjEwMTIzNmVjNDA4MmEzMGI0MCIsIm5hbWUiOiJKYXJyZWQgU3VtbmVyIiwiZW1haWwiOiJqYXJyZWRAZXhhbXBsZS5jb20ifQ.t3mKE4aRvDxAbV1GV_Zi8J7iTSGTI378uZXvBIOW_iE',
+              }),
+            }),
+          }),
+        },
+      },
+      description: '登入成功的使用者資料',
+    },
+  },
+})
+
+const FavoriteParamsSchema = z.object({
+  movieId: z.string().openapi({
+    param: {
+      name: 'movieId',
+      in: 'path',
+      description: '請輸入電影 ID',
+      required: true,
+    },
+    example: '663f7907f5b09cc307e80780',
+  }),
+})
+
+const POST_favorite = createRoute({
+  tags: ['Favorite'],
+  summary: '新增使用者收藏電影',
+  method: 'post',
+  path: '/api/favorites/{movieId}',
+  security: [
+    {
+      JWT_Token: [],
+    },
+  ],
+  request: {
+    params: FavoriteParamsSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.boolean().openapi({
+              example: true,
+            }),
+            data: z.object({
+              userId: z.string().openapi({
+                example: '663df6eb5ea60afb31e42eef',
+              }),
+              movieId: z.string().openapi({
+                example: '663f7907f5b09cc307e80780',
+              }),
+              _id: z.string().openapi({
+                example: '66446fe8027b6f10ffae65e0',
+              }),
+              __v: z.number().openapi({
+                example: 0,
+              }),
+            }),
+          }),
+        },
+      },
+      description: '成功新增收藏電影',
+    },
+  },
+})
+
+const DELETE_favorite = createRoute({
+  tags: ['Favorite'],
+  summary: '移除使用者收藏電影',
+  method: 'delete',
+  path: '/api/favorites/{movieId}',
+  request: {
+    params: FavoriteParamsSchema,
+  },
+  security: [
+    {
+      JWT_Token: [],
+    },
+  ],
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.boolean().openapi({
+              example: true,
+            }),
+            data: z.object({
+              _id: z.string().openapi({
+                example: '66446fe8027b6f10ffae65e0',
+              }),
+              userId: z.string().openapi({
+                example: '663df6eb5ea60afb31e42eef',
+              }),
+              movieId: z.string().openapi({
+                example: '663f7907f5b09cc307e80780',
+              }),
+              __v: z.number().openapi({
+                example: 0,
+              }),
+            }),
+          }),
+        },
+      },
+      description: '成功移除收藏電影',
+    },
+  },
+})
+
+const LikeAndDislikeParamsSchema = z.object({
+  commentId: z.string().openapi({
+    param: {
+      name: 'commentId',
+      in: 'path',
+      description: '請輸入評論 ID',
+      required: true,
+    },
+    example: '66422b160cf8b035aa816225',
+  }),
+})
+
+const POST_like = createRoute({
+  tags: ['Like'],
+  summary: '新增使用者按攢評論',
+  method: 'post',
+  path: '/api/like/{commentId}',
+  security: [
+    {
+      JWT_Token: [],
+    },
+  ],
+  request: {
+    params: LikeAndDislikeParamsSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.boolean().openapi({
+              example: true,
+            }),
+            data: z.object({
+              userId: z.string().openapi({
+                example: '663df6eb5ea60afb31e42eef',
+              }),
+              commentId: z.string().openapi({
+                example: '66422b160cf8b035aa816225',
+              }),
+              _id: z.string().openapi({
+                example: '664716496456e9695a421cfa',
+              }),
+              __v: z.number().openapi({
+                example: 0,
+              }),
+            }),
+          }),
+        },
+      },
+      description: '成功按攢評論',
+    },
+  },
+})
+
+const DELETE_like = createRoute({
+  tags: ['Like'],
+  summary: '移除使用者按攢評論',
+  method: 'delete',
+  path: '/api/like/{commentId}',
+  security: [
+    {
+      JWT_Token: [],
+    },
+  ],
+  request: {
+    params: LikeAndDislikeParamsSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.boolean().openapi({
+              example: true,
+            }),
+            data: z.object({
+              _id: z.string().openapi({
+                example: '664716496456e9695a421cfa',
+              }),
+              userId: z.string().openapi({
+                example: '663df6eb5ea60afb31e42eef',
+              }),
+              commentId: z.string().openapi({
+                example: '66422b160cf8b035aa816225',
+              }),
+              __v: z.number().openapi({
+                example: 0,
+              }),
+            }),
+          }),
+        },
+      },
+      description: '收回按攢評論',
+    },
+  },
+})
+
+const POST_dislike = createRoute({
+  tags: ['Dislike'],
+  summary: '新增使用者倒攢評論',
+  method: 'post',
+  path: '/api/dislike/{commentId}',
+  security: [
+    {
+      JWT_Token: [],
+    },
+  ],
+  request: {
+    params: LikeAndDislikeParamsSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.boolean().openapi({
+              example: true,
+            }),
+            data: z.object({
+              userId: z.string().openapi({
+                example: '663df6eb5ea60afb31e42eef',
+              }),
+              commentId: z.string().openapi({
+                example: '66422b160cf8b035aa816225',
+              }),
+              _id: z.string().openapi({
+                example: '664717b600608c91153b6ffd',
+              }),
+              __v: z.number().openapi({
+                example: 0,
+              }),
+            }),
+          }),
+        },
+      },
+      description: '成功倒攢評論',
+    },
+  },
+})
+
+const DELETE_dislike = createRoute({
+  tags: ['Dislike'],
+  summary: '移除使用者倒攢評論',
+  method: 'delete',
+  path: '/api/dislike/{commentId}',
+  security: [
+    {
+      JWT_Token: [],
+    },
+  ],
+  request: {
+    params: LikeAndDislikeParamsSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            success: z.boolean().openapi({
+              example: true,
+            }),
+            data: z.object({
+              _id: z.string().openapi({
+                example: '664717b600608c91153b6ffd',
+              }),
+              userId: z.string().openapi({
+                example: '663df6eb5ea60afb31e42eef',
+              }),
+              commentId: z.string().openapi({
+                example: '66422b160cf8b035aa816225',
+              }),
+              __v: z.number().openapi({
+                example: 0,
+              }),
+            }),
+          }),
+        },
+      },
+      description: '收回倒攢評論',
+    },
+  },
+})
+
+export function userRoute(app: OpenAPIHono) {
+  app.openapi(POST_signUp, userController.signUp)
+  app.openapi(POST_signIn, userController.signIn)
+  app.openapi(POST_favorite, favoriteController.addFavorite)
+  app.openapi(DELETE_favorite, favoriteController.removeFavorite)
+  app.openapi(POST_like, likeController.likeComment)
+  app.openapi(DELETE_like, likeController.undoLikeComment)
+  app.openapi(POST_dislike, dislikeController.dislikeComment)
+  app.openapi(DELETE_dislike, dislikeController.undoDislikeComment)
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "jsx": "react-jsx",
-    "jsxImportSource": "hono/jsx"
+    "jsxImportSource": "hono/jsx",
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
新增: 
1. swagger UI 介面 (路徑: /ui ) 及 swagger UI 文件(路徑: /doc)
2. heloers/error-message.ts 由 errorMessage() 統一處理回傳錯誤訊息的格式

修改:
1. app 的 instance 由 Hono 改為 OpenAPIHono 並將 context 型別改設為 any (尚不確定 OpenAPIHono 對應的 context 型別應為何? 😅) 
2. middlewares/error-handler.ts 改由 errorMessage() 處理回傳錯誤訊息格式；並可接受 err.status 的錯誤代碼設定
3. routes/user.ts 
  a.) 調整路由的撰寫方式，先定義 routes, params 的 Schema 於最後才撰寫相關路由；
  b.) 移除 jwt auth 的 middleware 改由後續 controller 來完成認證 (避免 OpenAPIHono 與原本 Hono 的 context 並不相符的差異) 
  c.) 移除 zValidator 的 middleware (避免 OpenAPIHono 與原本 Hono 的 context 並不相符的差異) 
4. controllers/user.ts, like.ts, favorite.ts, dislike.ts 調整資料回傳格式, 重構錯誤訊息處理, 進行 jwt auth 認證(若有)